### PR TITLE
MSP-015: Add springdoc-openapi-ui in User Service and Aunthentication Service

### DIFF
--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	// Annotation processors
 	annotationProcessor 'org.projectlombok:lombok' // Annotation processor for Lombok
 
+	// API Documentation
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 	// Testing dependencies
 	testImplementation 'org.springframework.boot:spring-boot-starter-test' // Starter for testing Spring Boot applications with libraries including JUnit, Hamcrest and Mockito
 	testImplementation 'org.springframework.security:spring-security-test' // Starter for testing Spring Security applications

--- a/UserService/src/main/java/com/microservices/userservice/UserServiceApplication.java
+++ b/UserService/src/main/java/com/microservices/userservice/UserServiceApplication.java
@@ -1,9 +1,14 @@
 package com.microservices.userservice;
 
 import io.github.cdimascio.dotenv.Dotenv;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableDiscoveryClient
@@ -30,6 +35,19 @@ public class UserServiceApplication {
 		System.setProperty("spring.datasource.url", url);
 
 		SpringApplication.run(UserServiceApplication.class, args);
+	}
+
+
+	@Bean
+	public OpenAPI customOpenAPI(@Value("${application-description}") String appDesciption,
+								 @Value("${application-version}") String appVersion) {
+		return new OpenAPI()
+				.info(new Info()
+						.title("User Service REST Endpoints")
+						.version(appVersion)
+						.description(appDesciption)
+						.termsOfService("http://swagger.io/terms/")
+						.license(new License().name("Apache 2.0").url("http://springdoc.org")));
 	}
 
 }

--- a/UserService/src/main/java/com/microservices/userservice/security/config/SecurityConfig.java
+++ b/UserService/src/main/java/com/microservices/userservice/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -19,6 +20,15 @@ public class SecurityConfig {
 
     public SecurityConfig(JwtTokenVerifier jwtTokenVerifier) {
         this.jwtTokenVerifier = jwtTokenVerifier;
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers(
+                "/api-docs/**",
+                "/swagger-ui/**",
+                "/v3/api-docs/**"
+        );
     }
 
     @Bean

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -57,3 +57,9 @@ management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always
 management.metrics.enable.jvm=true
 management.prometheus.metrics.export.enabled=true
+
+# API Documentation
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+application-description=User Service
+application-version=1.0.0


### PR DESCRIPTION
# MSP-015: Add Springdoc OpenAPI UI in User Service (Part I)

## Overview
This pull request introduces the integration of the Springdoc OpenAPI UI to enhance API documentation visibility in the User Service and Authentication modules. The implementation includes updates to the build configurations, Java class modifications for API documentation annotations, and security configurations adjustments to expose the API docs endpoints.

## Changes

### Gradle Dependencies
- Added `org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0` for API documentation.

### Java Classes
- Introduced `@Bean` method `customOpenAPI` in `UserServiceApplication.java` to customize OpenAPI configuration.
- Updated `SecurityConfig.java` to exclude API documentation paths (`/api-docs/**`, `/swagger-ui.html`, `/v3/api-docs/**`) from security restrictions.

### Properties File
- Added new properties in `application.properties` for API documentation paths and descriptions.

## Impact
- **API Visibility:** The integration of Springdoc OpenAPI UI will allow for better visibility and interaction with the API endpoints through a generated user interface.
- **Security:** Adjusted security settings to ensure API documentation endpoints are accessible without authentication, improving ease of use during development and testing phases.