### PR TITLE
MSP-015: Add springdoc-openapi-ui in Authentication Service

### DIFF
--- a/AuthenticationService/build.gradle
+++ b/AuthenticationService/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	// Annotation processors
 	annotationProcessor 'org.projectlombok:lombok' // Annotation processor for Lombok
 
+	// API Documentation
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 	// Testing dependencies
 	testImplementation 'org.springframework.boot:spring-boot-starter-test' // Starter for testing Spring Boot applications with libraries including JUnit, Hamcrest and Mockito
 	testImplementation 'org.springframework.security:spring-security-test' // Starter for testing Spring Security applications

--- a/AuthenticationService/src/main/java/com/microservices/authenticationservice/AuthenticationServiceApplication.java
+++ b/AuthenticationService/src/main/java/com/microservices/authenticationservice/AuthenticationServiceApplication.java
@@ -1,9 +1,14 @@
 package com.microservices.authenticationservice;
 
 import io.github.cdimascio.dotenv.Dotenv;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 @EnableDiscoveryClient
@@ -30,6 +35,18 @@ public class AuthenticationServiceApplication {
 		System.setProperty("spring.datasource.url", url);
 
 		SpringApplication.run(AuthenticationServiceApplication.class, args);
+	}
+
+	@Bean
+	public OpenAPI customOpenAPI(@Value("${application-description}") String appDesciption,
+								 @Value("${application-version}") String appVersion) {
+		return new OpenAPI()
+				.info(new Info()
+						.title("Authentication Service REST Endpoints")
+						.version(appVersion)
+						.description(appDesciption)
+						.termsOfService("http://swagger.io/terms/")
+						.license(new License().name("Apache 2.0").url("http://springdoc.org")));
 	}
 
 }

--- a/AuthenticationService/src/main/java/com/microservices/authenticationservice/security/config/SecurityConfig.java
+++ b/AuthenticationService/src/main/java/com/microservices/authenticationservice/security/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +32,15 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers(
+                "/api-docs/**",
+                "/swagger-ui/**",
+                "/v3/api-docs/**"
+        );
     }
 
     @Bean

--- a/AuthenticationService/src/main/resources/application.properties
+++ b/AuthenticationService/src/main/resources/application.properties
@@ -52,3 +52,9 @@ management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.show-details=always
 management.metrics.enable.jvm=true
 management.prometheus.metrics.export.enabled=true
+
+# API Documentation
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+application-description=Authentication Service
+application-version=1.0.0


### PR DESCRIPTION
# MSP-015: Add Springdoc OpenAPI UI in Authentication Service (Part II)

## Overview
This pull request introduces the integration of the Springdoc OpenAPI UI to enhance API documentation visibility in the Authentication module. The implementation includes updates to the build configurations, Java class modifications for API documentation annotations, and security configurations adjustments to expose the API docs endpoints.

## Changes

### Gradle Dependencies
- Added `org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0` for API documentation.

### Java Classes
- Introduced `@Bean` method `customOpenAPI` in `AuthenticationServiceApplication.java` to customize OpenAPI configuration.
- Updated `SecurityConfig.java` to exclude API documentation paths (`/api-docs/**`, `/swagger-ui.html`, `/v3/api-docs/**`) from security restrictions.

### Properties File
- Added new properties in `application.properties` for API documentation paths and descriptions.

### Testing
![image](https://github.com/j0rgel0/Microservices/assets/102724257/44aaa69c-f851-4426-85a5-0715b3728740)
